### PR TITLE
Dynamic network fixes (for flannel compatibility)

### DIFF
--- a/src/github.com/cppforlife/bosh-docker-cpi/vm/networks.go
+++ b/src/github.com/cppforlife/bosh-docker-cpi/vm/networks.go
@@ -23,6 +23,9 @@ var (
 
 	// network with name foo3 already exists
 	alreadyExistsCheck = "already exists"
+
+	// operation is not permitted on predefined bridge network
+	predifinedNetworkCheck = "not permitted on predefined"
 )
 
 type Networks struct {
@@ -149,7 +152,8 @@ func (n Networks) createDynamicNetwork(netProps NetProps) (string, error) {
 
 	_, err := n.dkrClient.NetworkCreate(context.TODO(), netProps.Name, createOpts)
 	if err != nil {
-		if !strings.Contains(err.Error(), alreadyExistsCheck) {
+		if !(strings.Contains(err.Error(), alreadyExistsCheck) ||
+			strings.Contains(err.Error(), predifinedNetworkCheck)) {
 			return "", err
 		}
 	}

--- a/src/github.com/cppforlife/bosh-docker-cpi/vm/networks.go
+++ b/src/github.com/cppforlife/bosh-docker-cpi/vm/networks.go
@@ -95,10 +95,12 @@ func (n Networks) networkingConfig(netConfigPairs []netConfigPair) *dkrnet.Netwo
 			IPAMConfig: &dkrnet.EndpointIPAMConfig{},
 		}
 
-		if newIPAddr(pair.Network.IP()).IsV6() {
-			endPtConfig.IPAMConfig.IPv6Address = pair.Network.IP()
-		} else {
-			endPtConfig.IPAMConfig.IPv4Address = pair.Network.IP()
+		if len(pair.Network.Netmask()) != 0 {
+			if newIPAddr(pair.Network.IP()).IsV6() {
+				endPtConfig.IPAMConfig.IPv6Address = pair.Network.IP()
+			} else {
+				endPtConfig.IPAMConfig.IPv4Address = pair.Network.IP()
+			}
 		}
 
 		netConfig.EndpointsConfig[pair.Props.Name] = endPtConfig

--- a/src/github.com/cppforlife/bosh-docker-cpi/vm/networks.go
+++ b/src/github.com/cppforlife/bosh-docker-cpi/vm/networks.go
@@ -98,7 +98,7 @@ func (n Networks) networkingConfig(netConfigPairs []netConfigPair) *dkrnet.Netwo
 			IPAMConfig: &dkrnet.EndpointIPAMConfig{},
 		}
 
-		if len(pair.Network.Netmask()) != 0 {
+		if !pair.Network.IsDynamic() {
 			if newIPAddr(pair.Network.IP()).IsV6() {
 				endPtConfig.IPAMConfig.IPv6Address = pair.Network.IP()
 			} else {
@@ -120,7 +120,7 @@ func (n Networks) enableSingleNetwork(network apiv1.Network) (NetProps, error) {
 		return NetProps{}, bosherr.WrapError(err, "Unmarshaling network properties")
 	}
 
-	if len(network.Netmask()) == 0 {
+	if network.IsDynamic() {
 		netProps.Name, err = n.createDynamicNetwork(netProps)
 		if err != nil {
 			return NetProps{}, bosherr.WrapError(err, "Creating dynamic network")


### PR DESCRIPTION
This PR fixes 2 issues which where encountered when trying to use the docker cpi with a docker daemon which uses flannel.
In this setup the default docker bridge network is backed by flannel, and can not be modified. It should be used with dynamic network mode.
I also encountered an issue where the cpi was trying to assign ip addresses while in dynamic mode. Which is, if I understand dynamic networking correctly, not correct.