### PR TITLE
add platform string to import options

### DIFF
--- a/src/bosh-docker-cpi/stemcell/fs_importer.go
+++ b/src/bosh-docker-cpi/stemcell/fs_importer.go
@@ -75,6 +75,7 @@ func (i FSImporter) ImportFromPath(imagePath string) (Stemcell, error) {
 	opts := dkrimages.ImportOptions{
 		Message: "bosh",
 		Tag:     id,
+		Platform: "linux/amd64",
 	}
 
 	repo := "bosh.io/stemcells"


### PR DESCRIPTION
add platform string to correctly import stemcells on multi-arch systems