### PR TITLE
Ensure more workloads can run

### DIFF
--- a/jobs/docker_cpi/spec
+++ b/jobs/docker_cpi/spec
@@ -39,5 +39,8 @@ properties:
     description: "Options for the blobstore used by deployed BOSH agents"
     default: {}
   docker_cpi.start_containers_with_systemd:
-    description: "Containers will use /sbin/init as the entry point. Enabling this is required for Noble stemcells, but currently breaks all pre-Noble stemcells"
+    description: "Containers will use /sbin/init as the entry point. Enabling this is required for Noble stemcells."
+    default: false
+  docker_cpi.enable_lxcfs_support:
+    description: "Enable LXCFS support for containers"
     default: false

--- a/src/bosh-docker-cpi/config/config.go
+++ b/src/bosh-docker-cpi/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Actions FactoryOpts
 
 	StartContainersWithSystemD bool `json:"start_containers_with_systemd"`
+	EnableLXCFSSupport         bool `json:"enable_lxcfs_support"`
 }
 
 type DockerOpts struct {


### PR DESCRIPTION
* Add LCXFS (optionally) to attempt to fake "VM" memory info properly inside of containers. This will allow workloads to properly understand their container limited memory and adjust accordingly
* Enhance the way we startup container processes with systemd, by removing a lot of unncessary systemd units that weren't working well inside of the containers. Using systemd should not require noble anymore, and is more likely to work.
* Bind mount in kernel modules directory so that inside stemcell version does not have to exactly match the host kernel version