### PR TITLE
Do not umount /etc/hosts twice

### DIFF
--- a/src/bosh-docker-cpi/vm/factory.go
+++ b/src/bosh-docker-cpi/vm/factory.go
@@ -195,20 +195,6 @@ func (f Factory) Create(agentID apiv1.AgentID, stemcell bstem.Stemcell,
 		return Container{}, bosherr.WrapError(err, "Starting container")
 	}
 
-	if startContainersWithSystemD {
-		execProcess, err := f.dkrClient.ContainerExecCreate(context.TODO(), id.AsString(), dkrcont.ExecOptions{Cmd: []string{"bash", "-c", "umount /etc/hosts"}})
-		if err != nil {
-			f.cleanUpContainer(container)
-			return Container{}, bosherr.WrapError(err, "Creating exec")
-		}
-
-		err = f.dkrClient.ContainerExecStart(context.TODO(), execProcess.ID, dkrcont.ExecStartOptions{})
-		if err != nil {
-			f.cleanUpContainer(container)
-			return Container{}, bosherr.WrapError(err, "Starting exec")
-		}
-	}
-
 	agentEnv := apiv1.AgentEnvFactory{}.ForVM(agentID, id, networks, env, f.agentOptions)
 	agentEnv.AttachSystemDisk(apiv1.NewDiskHintFromString(""))
 


### PR DESCRIPTION
The `umount /etc/hosts` command when starting with systemd is already run in the container start command; running it via `docker exec` after starting the container may result in a race condition. If the container start execution happens first, then the `docker exec` execution will fail, but we never check the exit code so it doesn't cause problems. If the `docker exec` execution happens first, then the container start execution will fail, causing the container to die.