### PR TITLE
set GOCACHE to tmp for create-env

### DIFF
--- a/packages/docker_cpi/packaging
+++ b/packages/docker_cpi/packaging
@@ -10,6 +10,11 @@ fi
 
 source ${pkg_dir}/bosh/compile.env
 
+# Since HOME is not set we must set GOPATH and GOCACHE
+mkdir -p /tmp/go/.cache
+export GOPATH=/tmp/go
+export GOCACHE=${GOPATH}/.cache
+
 mkdir ../src && cp -a * ../src/ && mv ../src ./src
 
 mkdir -p $BOSH_INSTALL_TARGET/bin


### PR DESCRIPTION
set GOCACHE otherwise while running on a local machine it tries to install it in /var/vcap/data/golang-1-linux/cache
