### PR TITLE
on noble the bohs-agent runs on systemd so it should not be remoed

### DIFF
--- a/src/bosh-docker-cpi/vm/factory.go
+++ b/src/bosh-docker-cpi/vm/factory.go
@@ -116,7 +116,7 @@ func (f Factory) Create(agentID apiv1.AgentID, stemcell bstem.Stemcell,
 		removeNonCriticalSystemdServices := `find /etc/systemd/system ` +
 			`/lib/systemd/system -path '*.wants/*' -not -name '*journald*' ` +
 			`-not -name '*systemd-tmpfiles*' -not -name '*systemd-user-sessions*' ` +
-			`-not -name '*runit*' -exec rm \{} \;`
+			`-not -name '*runit*' -not -name '*bosh-agent*' -exec rm \{} \;`
 
 		systemdInitCmds := []string{
 			`rm -rf /etc/sv/{ssh,cron}`,


### PR DESCRIPTION
in commit cd2db37e614c261d02fc241a7a871a44827d7110 there is a new function created where it removes some systemd related things that prevented the agent from ever starting up on a noble stemcell