### PR TITLE
logrotate should still work when starting with systemd

### DIFF
--- a/src/bosh-docker-cpi/vm/factory.go
+++ b/src/bosh-docker-cpi/vm/factory.go
@@ -114,7 +114,8 @@ func (f Factory) Create(agentID apiv1.AgentID, stemcell bstem.Stemcell,
 		// only load minimal set of systemd units / services
 		// https://github.com/asg1612/docker-systemd/blob/master/Dockerfile
 		removeNonCriticalSystemdServices := `find /etc/systemd/system ` +
-			`/lib/systemd/system -path '*.wants/*' -not -name '*journald*' ` +
+			`/lib/systemd/system -path '*.wants/*'` +
+			`-not -name '*journald*' -not -name '*logrotate*'` +
 			`-not -name '*systemd-tmpfiles*' -not -name '*systemd-user-sessions*' ` +
 			`-not -name '*runit*' -not -name '*bosh-agent*' -exec rm \{} \;`
 


### PR DESCRIPTION
I got onto a vm with the stemcell `bosh-google-kvm-ubuntu-jammy-go_agent/1.954` just to see what was there and saw:

```shell
> find /etc/systemd/system /lib/systemd/system -path '*.wants/*' | grep logrotate
  /etc/systemd/system/timers.target.wants/logrotate.timer
  
> cat /etc/systemd/system/timers.target.wants/logrotate.timer
[Unit]
Description=Daily rotation of log files
Documentation=man:logrotate(8) man:logrotate.conf(5)

[Timer]
OnCalendar=daily
AccuracySec=1h
Persistent=true

[Install]
WantedBy=timers.target
```

Idk if that is the best frame of reference, but the existing find command would remove that, probably resulting in logrotate not running.

reference: https://github.com/cloudfoundry/bosh-docker-cpi-release/commit/cd2db37e614c261d02fc241a7a871a44827d7110