### PR TITLE
Fix Integration Tests: use jammy stemcell

### DIFF
--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -183,6 +183,7 @@ function main() {
     -o ../bosh-deployment/docker/cpi.yml \
     -o ../bosh-deployment/docker/use-jammy.yml \
     -o ../bosh-deployment/jumpbox-user.yml \
+    -o ../bosh-deployment/misc/source-releases/bosh.yml \
     -o manifests/dev.yml \
     -v director_name=docker \
     -v docker_cpi_path=$cpi_path \


### PR DESCRIPTION
# Context

From what I understand, docker cpi still doesn't work with noble (https://github.com/cloudfoundry/bosh-docker-cpi-release/issues/28), and bosh deployment now has noble as the default stemcell.

Strangely, it looks like on [Oct 9, we switched to noble](https://github.com/cloudfoundry/bosh-deployment/commit/34e368fca5d2369defbb36fa4c893b23a4554b35), but there have been [passing builds since Oct 11](https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-docker-cpi/jobs/integration-test/builds/113) using a [version of bosh-deployment from Oct 10](https://github.com/cloudfoundry/bosh-deployment/commit/045ef139332c18d1152eaf475096970eb029a98b)

The failing build did include [a bump to noble though](https://github.com/cloudfoundry/bosh-deployment/commit/a22d3db586cf0f6f099c88f3716228bcb1fa22e1) in bosh-deployment.

I wonder if we just got lucky it was working?

# Changes

Uses ops-files from bosh deployment to use the Jammy stemcell, and do source-releases for bosh.

I tried it out here: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-docker-cpi/jobs/integration-test/builds/128

It passed, though it does make things a bit slower now.