### PR TITLE
Switch custom resource types to registry-image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -327,12 +327,12 @@ resources:
 
 resource_types:
 - name: gcs-resource
-  type: docker-image
+  type: registry-image
   source:
     repository: frodenas/gcs-resource
 
 - name: bosh-io-stemcell
-  type: docker-image
+  type: registry-image
   source:
     repository: foundationalinfrastructure/bosh-io-stemcell-resource
     tag: v1.2.1


### PR DESCRIPTION
Using docker-image for the type was leading to a cloudflare challenge when checking.

(already flown)