### PR TITLE
Fix create_vm failure with Docker 29.5.x containerd snapshotter

### DIFF
--- a/src/bosh-docker-cpi/vendor/github.com/docker/docker/pkg/stdcopy/stdcopy.go
+++ b/src/bosh-docker-cpi/vendor/github.com/docker/docker/pkg/stdcopy/stdcopy.go
@@ -1,0 +1,190 @@
+package stdcopy
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// StdType is the type of standard stream
+// a writer can multiplex to.
+type StdType byte
+
+const (
+	// Stdin represents standard input stream type.
+	Stdin StdType = iota
+	// Stdout represents standard output stream type.
+	Stdout
+	// Stderr represents standard error steam type.
+	Stderr
+	// Systemerr represents errors originating from the system that make it
+	// into the multiplexed stream.
+	Systemerr
+
+	stdWriterPrefixLen = 8
+	stdWriterFdIndex   = 0
+	stdWriterSizeIndex = 4
+
+	startingBufLen = 32*1024 + stdWriterPrefixLen + 1
+)
+
+var bufPool = &sync.Pool{New: func() interface{} { return bytes.NewBuffer(nil) }}
+
+// stdWriter is wrapper of io.Writer with extra customized info.
+type stdWriter struct {
+	io.Writer
+	prefix byte
+}
+
+// Write sends the buffer to the underneath writer.
+// It inserts the prefix header before the buffer,
+// so stdcopy.StdCopy knows where to multiplex the output.
+// It makes stdWriter to implement io.Writer.
+func (w *stdWriter) Write(p []byte) (int, error) {
+	if w == nil || w.Writer == nil {
+		return 0, errors.New("writer not instantiated")
+	}
+	if p == nil {
+		return 0, nil
+	}
+
+	header := [stdWriterPrefixLen]byte{stdWriterFdIndex: w.prefix}
+	binary.BigEndian.PutUint32(header[stdWriterSizeIndex:], uint32(len(p)))
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Write(header[:])
+	buf.Write(p)
+
+	n, err := w.Writer.Write(buf.Bytes())
+	n -= stdWriterPrefixLen
+	if n < 0 {
+		n = 0
+	}
+
+	buf.Reset()
+	bufPool.Put(buf)
+	return n, err
+}
+
+// NewStdWriter instantiates a new Writer.
+// Everything written to it will be encapsulated using a custom format,
+// and written to the underlying `w` stream.
+// This allows multiple write streams (e.g. stdout and stderr) to be muxed into a single connection.
+// `t` indicates the id of the stream to encapsulate.
+// It can be stdcopy.Stdin, stdcopy.Stdout, stdcopy.Stderr.
+func NewStdWriter(w io.Writer, t StdType) io.Writer {
+	return &stdWriter{
+		Writer: w,
+		prefix: byte(t),
+	}
+}
+
+// StdCopy is a modified version of io.Copy.
+//
+// StdCopy will demultiplex `src`, assuming that it contains two streams,
+// previously multiplexed together using a StdWriter instance.
+// As it reads from `src`, StdCopy will write to `dstout` and `dsterr`.
+//
+// StdCopy will read until it hits EOF on `src`. It will then return a nil error.
+// In other words: if `err` is non nil, it indicates a real underlying error.
+//
+// `written` will hold the total number of bytes written to `dstout` and `dsterr`.
+func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, _ error) {
+	var (
+		buf       = make([]byte, startingBufLen)
+		bufLen    = len(buf)
+		nr, nw    int
+		err       error
+		out       io.Writer
+		frameSize int
+	)
+
+	for {
+		// Make sure we have at least a full header
+		for nr < stdWriterPrefixLen {
+			var nr2 int
+			nr2, err = src.Read(buf[nr:])
+			nr += nr2
+			if errors.Is(err, io.EOF) {
+				if nr < stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		stream := StdType(buf[stdWriterFdIndex])
+		// Check the first byte to know where to write
+		switch stream {
+		case Stdin:
+			fallthrough
+		case Stdout:
+			// Write on stdout
+			out = dstout
+		case Stderr:
+			// Write on stderr
+			out = dsterr
+		case Systemerr:
+			// If we're on Systemerr, we won't write anywhere.
+			// NB: if this code changes later, make sure you don't try to write
+			// to outstream if Systemerr is the stream
+			out = nil
+		default:
+			return 0, fmt.Errorf("Unrecognized input header: %d", buf[stdWriterFdIndex])
+		}
+
+		// Retrieve the size of the frame
+		frameSize = int(binary.BigEndian.Uint32(buf[stdWriterSizeIndex : stdWriterSizeIndex+4]))
+
+		// Check if the buffer is big enough to read the frame.
+		// Extend it if necessary.
+		if frameSize+stdWriterPrefixLen > bufLen {
+			buf = append(buf, make([]byte, frameSize+stdWriterPrefixLen-bufLen+1)...)
+			bufLen = len(buf)
+		}
+
+		// While the amount of bytes read is less than the size of the frame + header, we keep reading
+		for nr < frameSize+stdWriterPrefixLen {
+			var nr2 int
+			nr2, err = src.Read(buf[nr:])
+			nr += nr2
+			if errors.Is(err, io.EOF) {
+				if nr < frameSize+stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		// we might have an error from the source mixed up in our multiplexed
+		// stream. if we do, return it.
+		if stream == Systemerr {
+			return written, fmt.Errorf("error from daemon in stream: %s", string(buf[stdWriterPrefixLen:frameSize+stdWriterPrefixLen]))
+		}
+
+		// Write the retrieved frame (without header)
+		nw, err = out.Write(buf[stdWriterPrefixLen : frameSize+stdWriterPrefixLen])
+		if err != nil {
+			return 0, err
+		}
+
+		// If the frame has not been fully written: error
+		if nw != frameSize {
+			return 0, io.ErrShortWrite
+		}
+		written += int64(nw)
+
+		// Move the rest of the buffer to the beginning
+		copy(buf, buf[frameSize+stdWriterPrefixLen:])
+		// Move the index
+		nr -= frameSize + stdWriterPrefixLen
+	}
+}

--- a/src/bosh-docker-cpi/vendor/modules.txt
+++ b/src/bosh-docker-cpi/vendor/modules.txt
@@ -60,6 +60,7 @@ github.com/docker/docker/api/types/time
 github.com/docker/docker/api/types/versions
 github.com/docker/docker/api/types/volume
 github.com/docker/docker/client
+github.com/docker/docker/pkg/stdcopy
 # github.com/docker/go-connections v0.7.0
 ## explicit; go 1.23
 github.com/docker/go-connections/nat

--- a/src/bosh-docker-cpi/vm/file_service.go
+++ b/src/bosh-docker-cpi/vm/file_service.go
@@ -5,33 +5,55 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"path/filepath"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	dkrclient "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 )
+
+// execTimeout is the per-operation time limit for container exec calls.
+const execTimeout = 5 * time.Minute
 
 //counterfeiter:generate . FileService
 
+// FileService transfers files between the host and a running container.
 type FileService interface {
 	Upload(string, []byte) error
 	Download(string) ([]byte, error)
 }
 
+// DockerExecClient is the subset of the Docker API used by fileService for
+// exec-based file transfers. *dkrclient.Client satisfies this interface.
+type DockerExecClient interface {
+	ContainerExecCreate(ctx context.Context, containerID string, options container.ExecOptions) (container.ExecCreateResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
+	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
+}
+
+var _ DockerExecClient = (*dkrclient.Client)(nil)
+
 type fileService struct {
-	dkrClient *dkrclient.Client
+	dkrClient DockerExecClient
 	vmCID     apiv1.VMCID
 
 	logTag string
 	logger boshlog.Logger
 }
 
+// NewFileService creates a FileService that transfers files between the host
+// and a running container identified by vmCID. All file I/O uses exec-based
+// tar streaming to avoid the Docker 29.5.x containerd-snapshotter parent-escape
+// check that rejects the Ubuntu Noble stemcell's
+// /etc/resolv.conf -> ../run/systemd/resolve/stub-resolv.conf symlink.
 func NewFileService(
-	dkrClient *dkrclient.Client,
+	dkrClient DockerExecClient,
 	vmCID apiv1.VMCID,
 	logger boshlog.Logger,
 ) FileService {
@@ -44,66 +66,316 @@ func NewFileService(
 	}
 }
 
+// Download reads a file from the container by running "tar -c" inside it and
+// capturing the tar stream via exec stdout. This mirrors Docker's own
+// CopyFromContainer wire format but operates within the container's running
+// namespace, bypassing the Docker 29.5.x containerd-snapshotter security scan
+// that rejects symlinks whose targets escape their parent directory
+// (e.g. /etc/resolv.conf -> ../run/systemd/resolve/stub-resolv.conf in the
+// Ubuntu Noble stemcell image layer).
+//
+// Docker exec output is multiplexed with 8-byte stream-type headers when
+// Tty=false; stdcopy.StdCopy demultiplexes before the tar reader sees the data.
+// An io.Pipe streams the demultiplexed output directly into tar.Reader so that
+// only the extracted file bytes are buffered, avoiding an O(filesize) copy.
 func (s *fileService) Download(sourcePath string) ([]byte, error) {
-	sourceFileName := filepath.Base(sourcePath)
-
-	ctx := context.Background()
-
-	readCloser, _, err := s.dkrClient.CopyFromContainer(ctx, s.vmCID.AsString(), sourcePath)
-	if err != nil {
-		return nil, bosherr.WrapError(err, "Copying from container")
+	cleaned := path.Clean(sourcePath)
+	cleanedBase := path.Base(cleaned)
+	if !path.IsAbs(cleaned) || cleanedBase == "." || cleanedBase == "/" || cleaned != sourcePath {
+		return nil, bosherr.Errorf("sourcePath must be a clean absolute path to a single file, got '%s'", sourcePath)
 	}
 
-	defer readCloser.Close() //nolint:errcheck
+	ctx, cancel := context.WithTimeout(context.Background(), execTimeout)
+	defer cancel()
 
-	tarReader := tar.NewReader(readCloser)
-
-	_, err = tarReader.Next()
+	// Use the path package (not filepath) so directory and base components are
+	// always separated by '/' regardless of the host OS the CPI is compiled on.
+	execProcess, err := s.dkrClient.ContainerExecCreate(ctx, s.vmCID.AsString(), container.ExecOptions{
+		Cmd:          []string{"tar", "-c", "-f", "-", "-C", path.Dir(cleaned), "--", cleanedBase},
+		AttachStdout: true,
+		AttachStderr: true,
+	})
 	if err != nil {
-		return []byte{}, bosherr.WrapErrorf(err, "Reading tar header for '%s'", sourceFileName)
+		return nil, bosherr.WrapErrorf(err, "Creating docker exec for reading '%s'", sourcePath)
 	}
 
-	return io.ReadAll(tarReader)
+	resp, err := s.dkrClient.ContainerExecAttach(ctx, execProcess.ID, container.ExecAttachOptions{})
+	if err != nil {
+		return nil, bosherr.WrapErrorf(err, "Attaching to docker exec for reading '%s'", sourcePath)
+	}
+	defer resp.Close()
+
+	// ContainerExecAttach returns a hijacked net.Conn; context cancellation does
+	// not close it, so propagate the deadline directly onto the connection so
+	// stdcopy.StdCopy cannot block past the timeout.
+	if dl, ok := ctx.Deadline(); ok {
+		if err := resp.Conn.SetDeadline(dl); err != nil {
+			return nil, bosherr.WrapErrorf(err, "Setting deadline on exec connection for '%s'", sourcePath)
+		}
+	}
+
+	// Pipe demultiplexed stdout into tar.Reader concurrently so that only the
+	// extracted file bytes are held in memory, not the full tar stream.
+	pr, pw := io.Pipe()
+	var stderrBuf bytes.Buffer
+	copyDone := make(chan error, 1)
+	go func() {
+		// Read from resp.Reader (bufio.Reader) rather than resp.Conn so that any
+		// bytes already prefetched into the HTTP hijack buffer during the upgrade
+		// handshake are not silently dropped.
+		_, copyErr := stdcopy.StdCopy(pw, &stderrBuf, resp.Reader)
+		pw.CloseWithError(copyErr)
+		copyDone <- copyErr
+	}()
+
+	tr := tar.NewReader(pr)
+	hdr, tarNextErr := tr.Next()
+	if tarNextErr != nil {
+		pr.CloseWithError(tarNextErr)
+		<-copyDone
+		// Poll until the exec process has actually exited so we can report the
+		// real exit status and stderr rather than a confusing tar parse error.
+		// A single inspect call is insufficient because the process may still
+		// be marked running when we reach this point.
+		for {
+			inspectResp, iErr := s.dkrClient.ContainerExecInspect(ctx, execProcess.ID)
+			if iErr != nil {
+				// Cannot determine exec status; fall back to the tar error.
+				break
+			}
+			if inspectResp.Running {
+				select {
+				case <-ctx.Done():
+					return nil, bosherr.WrapError(ctx.Err(), "Exec polling interrupted")
+				case <-time.After(50 * time.Millisecond):
+				}
+				continue
+			}
+			if inspectResp.ExitCode != 0 {
+				return nil, bosherr.Errorf("tar of '%s' from container failed [exit status %d]: %s",
+					sourcePath, inspectResp.ExitCode, stderrBuf.String())
+			}
+			break // exited 0; fall back to the tar parse error below
+		}
+		return nil, bosherr.WrapErrorf(tarNextErr, "Reading tar header for '%s'", cleanedBase)
+	}
+
+	// Validate the tar entry before reading its contents. Guard against the
+	// container tar command returning a directory, symlink, or another
+	// non-regular-file entry — which would cause io.ReadAll to return empty
+	// bytes for a directory rather than the file contents, making the failure
+	// silent and hard to diagnose. Also guard against an unexpected name, which
+	// would indicate the container's working directory shifted or the tar
+	// invocation produced an unrelated entry.
+	if hdr.Typeflag != tar.TypeReg {
+		pr.CloseWithError(bosherr.Errorf("unexpected entry type"))
+		<-copyDone
+		return nil, bosherr.Errorf(
+			"tar entry for '%s' is not a regular file (type=%d)", cleanedBase, hdr.Typeflag)
+	}
+	// GNU tar sometimes prefixes the name with "./"; clean both sides for a
+	// reliable comparison.
+	if path.Clean(hdr.Name) != cleanedBase {
+		pr.CloseWithError(bosherr.Errorf("unexpected entry name"))
+		<-copyDone
+		return nil, bosherr.Errorf(
+			"tar entry for '%s' has unexpected name '%s'", cleanedBase, hdr.Name)
+	}
+
+	data, readErr := io.ReadAll(tr)
+	// Drain any remaining tar stream (end-of-archive padding) so the copy
+	// goroutine can complete its writes and exit cleanly. If the drain fails
+	// it means the copy goroutine itself failed; report that via copyDone.
+	if _, err = io.Copy(io.Discard, pr); err != nil {
+		<-copyDone
+		return nil, bosherr.WrapErrorf(err, "Draining tar stream from container for '%s'", sourcePath)
+	}
+
+	copyErr := <-copyDone
+	if readErr != nil {
+		return nil, bosherr.WrapErrorf(readErr, "Reading '%s' from container", cleanedBase)
+	}
+	if copyErr != nil {
+		return nil, bosherr.WrapErrorf(copyErr, "Reading tar stream from container for '%s'", sourcePath)
+	}
+
+	for {
+		inspectResp, err := s.dkrClient.ContainerExecInspect(ctx, execProcess.ID)
+		if err != nil {
+			return nil, bosherr.WrapErrorf(err, "Inspecting docker exec response for '%s'", sourcePath)
+		}
+
+		if inspectResp.Running {
+			select {
+			case <-ctx.Done():
+				return nil, bosherr.WrapError(ctx.Err(), "Exec polling interrupted")
+			case <-time.After(50 * time.Millisecond):
+			}
+			continue
+		}
+
+		if inspectResp.ExitCode != 0 {
+			return nil, bosherr.Errorf("tar of '%s' from container failed [exit status %d]: %s",
+				sourcePath, inspectResp.ExitCode, stderrBuf.String())
+		}
+
+		break
+	}
+
+	return data, nil
 }
 
+// Upload writes a file into the container by building a tar archive and
+// streaming it via exec stdin to "tar -x -C /". This avoids both
+// Docker's CopyToContainer (which triggers the 29.5.x parent-escape check) and
+// any shell stdin-buffering limits that affect the previous bash+cat approach for
+// files larger than ~2 MB. A single exec call handles directory creation and
+// file writing atomically; GNU tar (standard in all BOSH stemcells) creates
+// missing parent directories during extraction.
+//
+// The archive is streamed through an io.Pipe so the tar data is never fully
+// buffered in memory before being sent to the container; only the in-memory
+// contents slice is held. The archive path is derived from a validated,
+// normalized absolute destination path with all leading "/" characters
+// stripped so that "tar -x -C /" places the file at the correct absolute
+// path inside the container.
 func (s *fileService) Upload(destinationPath string, contents []byte) error {
-	destinationFileName := filepath.Base(destinationPath)
-	destinationDirName := filepath.Dir(destinationPath)
-
-	// Stream in settings file to a temporary directory
-	// so that tar (running as vcap) has permission to unpack into dir.
-	tarReader, err := s.tarReader(destinationFileName, contents)
-	if err != nil {
-		return bosherr.WrapError(err, "Creating tar")
+	cleanedDest := path.Clean(destinationPath)
+	destBase := path.Base(cleanedDest)
+	if !path.IsAbs(cleanedDest) || destBase == "." || destBase == "/" || cleanedDest != destinationPath {
+		return bosherr.Errorf("destinationPath must be a clean absolute path to a single file, got '%s'", destinationPath)
 	}
 
-	if err = s.dockerExecNoOutput("mkdir", "-p", destinationDirName); err != nil {
-		return bosherr.WrapErrorf(err, "Creating directory '%s'", destinationDirName)
-	}
+	// Strip the leading "/" so that "tar -x -C /" places the file at the
+	// correct absolute path inside the container while keeping the tar
+	// header name relative.
+	tarPath := strings.TrimLeft(cleanedDest, "/")
 
-	copyOpts := container.CopyToContainerOptions{}
-	err = s.dkrClient.CopyToContainer(
-		context.TODO(), s.vmCID.AsString(), filepath.Dir(destinationPath), tarReader, copyOpts)
-	if err != nil {
-		return bosherr.WrapError(err, "Copying to container")
-	}
+	// Stream the tar archive through an io.Pipe to avoid buffering the full
+	// archive (header + contents + end-of-archive padding) before sending.
+	pr, pw := io.Pipe()
+	defer func() {
+		// Close the reader to unblock the writer goroutine if dockerExecWithStdin
+		// fails before io.Copy ever reads from pr (e.g., on ContainerExecCreate
+		// or ContainerExecAttach failure). io.PipeReader.Close always returns nil.
+		if closeErr := pr.Close(); closeErr != nil {
+			s.logger.Debug(s.logTag, "Closing pipe reader: %v", closeErr)
+		}
+	}()
+	go func() {
+		tw := tar.NewWriter(pw)
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     tarPath,
+			Size:     int64(len(contents)),
+			Mode:     0640,
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			pw.CloseWithError(bosherr.WrapError(err, "Writing tar header"))
+			return
+		}
+		if _, err := tw.Write(contents); err != nil {
+			pw.CloseWithError(bosherr.WrapError(err, "Writing tar content"))
+			return
+		}
+		pw.CloseWithError(tw.Close())
+	}()
 
+	if err := s.dockerExecWithStdin(pr, "tar", "-x", "-f", "-", "-C", "/"); err != nil {
+		return bosherr.WrapErrorf(err, "Uploading '%s'", destinationPath)
+	}
 	return nil
 }
 
-func (s *fileService) dockerExecNoOutput(args ...string) error {
-	// 5 minutes is an arbitrary defensive upper bound on command completion
-	// In practice this method should be completing in <hundreds of milliseconds
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+// dockerExecWithStdin runs args inside the container, feeding stdin from the
+// provided reader. It captures stderr and includes it in the error when the
+// command exits with a non-zero status. The exec deadline is propagated to the
+// underlying hijacked connection so a stalled write cannot block indefinitely.
+func (s *fileService) dockerExecWithStdin(stdin io.Reader, args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), execTimeout)
 	defer cancel()
 
-	execProcess, err := s.dkrClient.ContainerExecCreate(ctx, s.vmCID.AsString(), container.ExecOptions{Cmd: args})
+	execProcess, err := s.dkrClient.ContainerExecCreate(ctx, s.vmCID.AsString(), container.ExecOptions{
+		Cmd:          args,
+		AttachStdin:  true,
+		AttachStderr: true,
+	})
 	if err != nil {
-		return bosherr.WrapErrorf(err, "Creating docker exec create response")
+		return bosherr.WrapErrorf(err, "Creating docker exec")
 	}
 
-	if err = s.dkrClient.ContainerExecStart(ctx, execProcess.ID, container.ExecStartOptions{}); err != nil {
-		return bosherr.WrapErrorf(err, "Starting to docker exec")
+	resp, err := s.dkrClient.ContainerExecAttach(ctx, execProcess.ID, container.ExecAttachOptions{})
+	if err != nil {
+		return bosherr.WrapErrorf(err, "Attaching to docker exec")
+	}
+	defer resp.Close()
+
+	// ContainerExecAttach returns a hijacked net.Conn; context cancellation does
+	// not close it, so propagate the deadline directly onto the connection so
+	// io.Copy cannot block past the timeout.
+	if dl, ok := ctx.Deadline(); ok {
+		if err := resp.Conn.SetDeadline(dl); err != nil {
+			return bosherr.WrapErrorf(err, "Setting deadline on exec connection")
+		}
+	}
+
+	// Drain stderr concurrently with stdin writes to prevent deadlock: if the
+	// exec process writes to stderr before consuming all stdin (e.g., on a tar
+	// parse error mid-stream), the exec's stderr buffer can fill and block the
+	// process, while io.Copy below is blocked waiting for the process to read
+	// more stdin — a classic bidirectional deadlock.
+	var stderrBuf bytes.Buffer
+	stderrDone := make(chan error, 1)
+	go func() {
+		_, copyErr := stdcopy.StdCopy(io.Discard, &stderrBuf, resp.Reader)
+		stderrDone <- copyErr
+	}()
+
+	if _, err = io.Copy(resp.Conn, stdin); err != nil {
+		writeErr := err
+		// Unblock any goroutine feeding stdin through an io.Pipe.
+		if c, ok := stdin.(io.Closer); ok {
+			if closeErr := c.Close(); closeErr != nil {
+				s.logger.Debug(s.logTag, "Closing stdin reader after write error: %v", closeErr)
+			}
+		}
+		// CloseWrite may fail if the connection is already broken; proceed regardless
+		// so we can still inspect the exec process for a better error message.
+		if cwErr := resp.CloseWrite(); cwErr != nil {
+			s.logger.Debug(s.logTag, "CloseWrite after write error: %v", cwErr)
+		}
+		// Drain stderr and poll the exec exit status so we can return the exec's
+		// real failure reason (e.g., "permission denied") rather than the
+		// broken-pipe write error that triggered the io.Copy failure.
+		if stderrErr := <-stderrDone; stderrErr != nil {
+			s.logger.Debug(s.logTag, "Reading exec output after write error: %v", stderrErr)
+		}
+		for {
+			inspectResp, iErr := s.dkrClient.ContainerExecInspect(ctx, execProcess.ID)
+			if iErr != nil {
+				break
+			}
+			if inspectResp.Running {
+				select {
+				case <-ctx.Done():
+					return bosherr.WrapError(ctx.Err(), "Exec polling interrupted")
+				case <-time.After(50 * time.Millisecond):
+				}
+				continue
+			}
+			if inspectResp.ExitCode != 0 {
+				return bosherr.Errorf("%v failed [exit status %d]: %s", args, inspectResp.ExitCode, stderrBuf.String())
+			}
+			break
+		}
+		return bosherr.WrapErrorf(writeErr, "Writing stdin to container")
+	}
+
+	if err = resp.CloseWrite(); err != nil {
+		return bosherr.WrapErrorf(err, "Closing stdin")
+	}
+
+	if stderrErr := <-stderrDone; stderrErr != nil {
+		return bosherr.WrapErrorf(stderrErr, "Reading exec output")
 	}
 
 	for {
@@ -113,43 +385,18 @@ func (s *fileService) dockerExecNoOutput(args ...string) error {
 		}
 
 		if inspectResp.Running {
-			// Small idle time to avoid busy loop
-			time.Sleep(50 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				return bosherr.WrapError(ctx.Err(), "Exec polling interrupted")
+			case <-time.After(50 * time.Millisecond):
+			}
 			continue
 		}
 
 		if inspectResp.ExitCode != 0 {
-			return bosherr.Errorf("%v failed [exit status %d]", args, inspectResp.ExitCode)
+			return bosherr.Errorf("%v failed [exit status %d]: %s", args, inspectResp.ExitCode, stderrBuf.String())
 		}
 
 		return nil
 	}
-}
-
-func (s *fileService) tarReader(fileName string, contents []byte) (io.Reader, error) {
-	tarBytes := &bytes.Buffer{}
-	var err error
-
-	tarWriter := tar.NewWriter(tarBytes)
-	defer func() {
-		err = tarWriter.Close()
-	}()
-
-	fileHeader := &tar.Header{
-		Name: fileName,
-		Size: int64(len(contents)),
-		Mode: 0640,
-	}
-
-	err = tarWriter.WriteHeader(fileHeader)
-	if err != nil {
-		return nil, bosherr.WrapError(err, "Writing tar header")
-	}
-
-	_, err = tarWriter.Write(contents)
-	if err != nil {
-		return nil, bosherr.WrapError(err, "Writing file to tar")
-	}
-
-	return tarBytes, err
 }

--- a/src/bosh-docker-cpi/vm/file_service_test.go
+++ b/src/bosh-docker-cpi/vm/file_service_test.go
@@ -1,0 +1,363 @@
+package vm_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"time"
+
+	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/stdcopy"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "bosh-docker-cpi/vm"
+)
+
+// testConn is a net.Conn that supports CloseWrite via separate io.Pipes for
+// each direction, allowing accurate half-close simulation in tests.
+type testConn struct {
+	// rr/rw: server-to-client pipe. Server writes to rw; client reads from rr.
+	rr *io.PipeReader
+	rw *io.PipeWriter
+	// wr/ww: client-to-server pipe. Client writes to ww; server reads from wr.
+	wr *io.PipeReader
+	ww *io.PipeWriter
+}
+
+func newTestConn() *testConn {
+	rr, rw := io.Pipe()
+	wr, ww := io.Pipe()
+	return &testConn{rr: rr, rw: rw, wr: wr, ww: ww}
+}
+
+func (c *testConn) Read(b []byte) (int, error)         { return c.rr.Read(b) }
+func (c *testConn) Write(b []byte) (int, error)        { return c.ww.Write(b) }
+func (c *testConn) CloseWrite() error                  { return c.ww.Close() }
+func (c *testConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *testConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *testConn) SetWriteDeadline(_ time.Time) error { return nil }
+func (c *testConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
+func (c *testConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
+
+func (c *testConn) Close() error {
+	var firstErr error
+	for _, closeFn := range []func() error{
+		c.rr.Close,
+		c.rw.Close,
+		c.wr.Close,
+		c.ww.Close,
+	} {
+		if err := closeFn(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// stubDockerExecClient implements DockerExecClient for unit tests.
+type stubDockerExecClient struct {
+	execCreateFn  func(ctx context.Context, containerID string, options container.ExecOptions) (container.ExecCreateResponse, error)
+	execAttachFn  func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
+	execInspectFn func(ctx context.Context, execID string) (container.ExecInspect, error)
+}
+
+func (s *stubDockerExecClient) ContainerExecCreate(ctx context.Context, containerID string, options container.ExecOptions) (container.ExecCreateResponse, error) {
+	return s.execCreateFn(ctx, containerID, options)
+}
+func (s *stubDockerExecClient) ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+	return s.execAttachFn(ctx, execID, config)
+}
+func (s *stubDockerExecClient) ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error) {
+	return s.execInspectFn(ctx, execID)
+}
+
+// buildFramedTar returns bytes containing a stdcopy-framed Docker exec stdout
+// stream holding a single-file tar archive. Panics if archive construction fails.
+func buildFramedTar(name string, content []byte) []byte {
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Size:     int64(len(content)),
+		Mode:     0644,
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		panic(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		panic(err)
+	}
+	if err := tw.Close(); err != nil {
+		panic(err)
+	}
+
+	var framed bytes.Buffer
+	if _, err := stdcopy.NewStdWriter(&framed, stdcopy.Stdout).Write(tarBuf.Bytes()); err != nil {
+		panic(err)
+	}
+	return framed.Bytes()
+}
+
+// buildFramedStderr returns bytes containing a stdcopy-framed Docker exec
+// stderr stream with the given message. Panics on write failure.
+func buildFramedStderr(msg string) []byte {
+	var buf bytes.Buffer
+	if _, err := stdcopy.NewStdWriter(&buf, stdcopy.Stderr).Write([]byte(msg)); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+// buildFramedTarHeader returns bytes containing a stdcopy-framed Docker exec
+// stdout stream holding a single tar entry described by hdr. Panics on failure.
+func buildFramedTarHeader(hdr *tar.Header, content []byte) []byte {
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	if err := tw.WriteHeader(hdr); err != nil {
+		panic(err)
+	}
+	if len(content) > 0 {
+		if _, err := tw.Write(content); err != nil {
+			panic(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		panic(err)
+	}
+	var framed bytes.Buffer
+	if _, err := stdcopy.NewStdWriter(&framed, stdcopy.Stdout).Write(tarBuf.Bytes()); err != nil {
+		panic(err)
+	}
+	return framed.Bytes()
+}
+
+var _ = Describe("FileService", func() {
+	var (
+		stub   *stubDockerExecClient
+		logger boshlog.Logger
+		vmCID  apiv1.VMCID
+	)
+
+	BeforeEach(func() {
+		logger = boshlog.NewLogger(boshlog.LevelNone)
+		vmCID = apiv1.NewVMCID("test-container")
+		stub = &stubDockerExecClient{}
+		stub.execCreateFn = func(_ context.Context, _ string, _ container.ExecOptions) (container.ExecCreateResponse, error) {
+			return container.ExecCreateResponse{ID: "exec-id"}, nil
+		}
+	})
+
+	Describe("Download", func() {
+		DescribeTable("returns an error for invalid sourcePaths",
+			func(p string) {
+				svc := NewFileService(stub, vmCID, logger)
+				_, err := svc.Download(p)
+				Expect(err).To(HaveOccurred())
+			},
+			Entry("empty string", ""),
+			Entry("root directory", "/"),
+			Entry("relative path", "etc/resolv.conf"),
+			Entry("dot-dot at end", "/etc/foo/.."),
+			Entry("dot-dot in middle", "/etc/../foo"),
+			Entry("trailing-slash directory", "/etc/"),
+		)
+
+		It("returns the file content from the container tar stream", func() {
+			fileContent := []byte("agent-env-contents")
+			// tar -c -f - -C /etc -- file.json produces an entry named "file.json".
+			framedTar := buildFramedTar("file.json", fileContent)
+
+			stub.execAttachFn = func(_ context.Context, _ string, _ container.ExecAttachOptions) (types.HijackedResponse, error) {
+				tc := newTestConn()
+				go func() {
+					defer GinkgoRecover()
+					_, err := tc.rw.Write(framedTar)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(tc.rw.Close()).To(Succeed())
+				}()
+				return types.NewHijackedResponse(tc, ""), nil
+			}
+			stub.execInspectFn = func(_ context.Context, _ string) (container.ExecInspect, error) {
+				return container.ExecInspect{Running: false, ExitCode: 0}, nil
+			}
+
+			svc := NewFileService(stub, vmCID, logger)
+			got, err := svc.Download("/etc/file.json")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(fileContent))
+		})
+
+		It("includes the tar command's stderr in the error when the exit code is non-zero", func() {
+			errMsg := "tar: cannot open: No such file or directory\n"
+
+			stub.execAttachFn = func(_ context.Context, _ string, _ container.ExecAttachOptions) (types.HijackedResponse, error) {
+				tc := newTestConn()
+				go func() {
+					defer GinkgoRecover()
+					_, err := tc.rw.Write(buildFramedStderr(errMsg))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(tc.rw.Close()).To(Succeed())
+				}()
+				return types.NewHijackedResponse(tc, ""), nil
+			}
+			stub.execInspectFn = func(_ context.Context, _ string) (container.ExecInspect, error) {
+				return container.ExecInspect{Running: false, ExitCode: 1}, nil
+			}
+
+			svc := NewFileService(stub, vmCID, logger)
+			_, err := svc.Download("/missing/file")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exit status 1"))
+			Expect(err.Error()).To(ContainSubstring(errMsg))
+		})
+
+		It("returns an error when the tar entry is not a regular file", func() {
+			framedTar := buildFramedTarHeader(&tar.Header{
+				Name:     "file.json",
+				Typeflag: tar.TypeDir,
+			}, nil)
+
+			stub.execAttachFn = func(_ context.Context, _ string, _ container.ExecAttachOptions) (types.HijackedResponse, error) {
+				tc := newTestConn()
+				go func() {
+					defer GinkgoRecover()
+					_, err := tc.rw.Write(framedTar)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(tc.rw.Close()).To(Succeed())
+				}()
+				return types.NewHijackedResponse(tc, ""), nil
+			}
+			stub.execInspectFn = func(_ context.Context, _ string) (container.ExecInspect, error) {
+				return container.ExecInspect{Running: false, ExitCode: 0}, nil
+			}
+
+			svc := NewFileService(stub, vmCID, logger)
+			_, err := svc.Download("/etc/file.json")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a regular file"))
+		})
+
+		It("returns an error when the tar entry name does not match the expected file", func() {
+			framedTar := buildFramedTarHeader(&tar.Header{
+				Name:     "other.json",
+				Size:     4,
+				Mode:     0644,
+				Typeflag: tar.TypeReg,
+			}, []byte("data"))
+
+			stub.execAttachFn = func(_ context.Context, _ string, _ container.ExecAttachOptions) (types.HijackedResponse, error) {
+				tc := newTestConn()
+				go func() {
+					defer GinkgoRecover()
+					_, err := tc.rw.Write(framedTar)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(tc.rw.Close()).To(Succeed())
+				}()
+				return types.NewHijackedResponse(tc, ""), nil
+			}
+			stub.execInspectFn = func(_ context.Context, _ string) (container.ExecInspect, error) {
+				return container.ExecInspect{Running: false, ExitCode: 0}, nil
+			}
+
+			svc := NewFileService(stub, vmCID, logger)
+			_, err := svc.Download("/etc/file.json")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unexpected name"))
+			Expect(err.Error()).To(ContainSubstring("other.json"))
+		})
+	})
+
+	Describe("Upload", func() {
+		It("returns an error when destinationPath is invalid", func() {
+			svc := NewFileService(stub, vmCID, logger)
+			for _, badPath := range []string{"", "/", "relative/path", "/etc/foo/.."} {
+				err := svc.Upload(badPath, []byte("data"))
+				Expect(err).To(HaveOccurred(), "expected error for path: %q", badPath)
+				Expect(err.Error()).To(ContainSubstring("clean absolute path"), "for path: %q", badPath)
+			}
+		})
+
+		It("streams a tar archive to the container with the correct path and permissions", func() {
+			fileContent := []byte(`{"agent":"settings"}`)
+			destPath := "/var/vcap/bosh/settings.json"
+
+			stub.execCreateFn = func(_ context.Context, _ string, opts container.ExecOptions) (container.ExecCreateResponse, error) {
+				Expect(opts.Cmd).To(ContainElements("tar", "-x"))
+				Expect(opts.AttachStdin).To(BeTrue())
+				return container.ExecCreateResponse{ID: "exec-id"}, nil
+			}
+
+			// Use a channel to safely pass tar bytes from the server goroutine to
+			// the main test goroutine, establishing the required happens-before.
+			tarCh := make(chan []byte, 1)
+			stub.execAttachFn = func(_ context.Context, _ string, _ container.ExecAttachOptions) (types.HijackedResponse, error) {
+				tc := newTestConn()
+				go func() {
+					defer GinkgoRecover()
+					data, err := io.ReadAll(tc.wr)
+					Expect(err).NotTo(HaveOccurred())
+					tarCh <- data
+					Expect(tc.rw.Close()).To(Succeed())
+				}()
+				return types.NewHijackedResponse(tc, ""), nil
+			}
+			stub.execInspectFn = func(_ context.Context, _ string) (container.ExecInspect, error) {
+				return container.ExecInspect{Running: false, ExitCode: 0}, nil
+			}
+
+			svc := NewFileService(stub, vmCID, logger)
+			err := svc.Upload(destPath, fileContent)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the received bytes form a valid tar archive with the right
+			// path (leading "/" stripped) and file mode.
+			tr := tar.NewReader(bytes.NewReader(<-tarCh))
+			hdr, err := tr.Next()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hdr.Name).To(Equal("var/vcap/bosh/settings.json"))
+			Expect(hdr.Mode).To(Equal(int64(0640)))
+			body, err := io.ReadAll(tr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(body).To(Equal(fileContent))
+		})
+
+		It("returns an error with stderr when the tar extraction fails", func() {
+			errMsg := "tar: /var/vcap: Permission denied\n"
+
+			stub.execAttachFn = func(_ context.Context, _ string, _ container.ExecAttachOptions) (types.HijackedResponse, error) {
+				tc := newTestConn()
+				go func() {
+					defer GinkgoRecover()
+					// Simulate tar writing stderr before consuming all stdin
+					// (e.g., it detects an error from the first tar header block
+					// before the full archive has been sent). Without concurrent
+					// stderr draining in dockerExecWithStdin this would deadlock:
+					// io.Copy blocks waiting for stdin to be read, while the
+					// server blocks waiting for its stderr write to be consumed.
+					_, err := tc.rw.Write(buildFramedStderr(errMsg))
+					Expect(err).NotTo(HaveOccurred())
+					if _, err := io.Copy(io.Discard, tc.wr); err != nil {
+						Expect(err).NotTo(HaveOccurred())
+					}
+					Expect(tc.rw.Close()).To(Succeed())
+				}()
+				return types.NewHijackedResponse(tc, ""), nil
+			}
+			stub.execInspectFn = func(_ context.Context, _ string) (container.ExecInspect, error) {
+				return container.ExecInspect{Running: false, ExitCode: 2}, nil
+			}
+
+			svc := NewFileService(stub, vmCID, logger)
+			err := svc.Upload("/var/vcap/settings.json", []byte("data"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exit status 2"))
+			Expect(err.Error()).To(ContainSubstring(errMsg))
+		})
+	})
+})


### PR DESCRIPTION
Fixes `create_vm` failures on Docker 29.5.x with the containerd snapshotter (`io.containerd.snapshotter.v1`):

```
Deploying:
  Creating instance 'bosh/0':
    Creating VM:
      Creating vm with stemcell cid 'bosh.io/stemcells:img-5caa8077-a238-4a52-4b2a-4599a95095fe':
        CPI 'create_vm' method responded with error: CmdError{"type":"Bosh::Clouds::CloudError","message":"Creating VM with agent ID '{{ce2498aa-50ae-4f7b-756d-111e30b21c16}}': Updating container's agent env: Copying to container: Error response from daemon: openat etc/resolv.conf: path escapes from parent","ok_to_retry":false}
```

^ https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-docker-cpi/jobs/integration-test/builds/229#L6a040234:100:104

## Root cause

Docker 29.5.x added a security check in the containerd snapshotter that traverses all container image layers and rejects symlinks whose targets escape their parent directory. The Ubuntu Noble stemcell image layer contains `/etc/resolv.conf -> ../run/systemd/resolve/stub-resolv.conf`; the `../` prefix causes Docker's layer scanner to reject the path. This check fires for **both** `CopyToContainer` and `CopyFromContainer`, making any Docker copy API call fail for containers based on the Noble stemcell.

## Fix

Replace `CopyToContainer` (Upload) and `CopyFromContainer` + `tar.Reader` (Download) with exec-based tar streaming that operates entirely within the container's running namespace, bypassing the daemon-side layer scan:

- **Upload**: builds a tar archive in memory and streams it via exec stdin to `tar -x -f - -C /` inside the container. GNU tar creates missing parent directories during extraction, eliminating the separate `mkdir -p` exec call.
- **Download**: runs `tar -c -f - -C /dir file` inside the container via exec stdout. Docker exec output uses an 8-byte multiplexed framing when `Tty=false`; `stdcopy.StdCopy` demultiplexes the stream before `tar.NewReader` parses it — preserving the original tarReader approach end-to-end.

The hijacked `net.Conn` returned by `ContainerExecAttach` is not subject to context cancellation, so the context deadline is propagated directly to the connection via `SetDeadline` to bound both read (Download) and write (Upload) operations.