### PR TITLE
Make cgroupfs bind mount configurable (fix cgroup v1 `runc delete` EBUSY)

### DIFF
--- a/jobs/docker_cpi/spec
+++ b/jobs/docker_cpi/spec
@@ -41,6 +41,9 @@ properties:
   docker_cpi.start_containers_with_systemd:
     description: "Containers will use /sbin/init as the entry point. Enabling this is required for Noble stemcells."
     default: false
+  docker_cpi.mount_cgroupfs:
+    description: "Bind-mount the host /sys/fs/cgroup into systemd containers (required for cgroups v2; set false on cgroups v1 hosts to avoid the dying-cgroup runc delete failure). Only takes effect when start_containers_with_systemd is true."
+    default: true
   docker_cpi.enable_lxcfs_support:
     description: "Enable LXCFS support for containers"
     default: false

--- a/jobs/docker_cpi/templates/cpi.json.erb
+++ b/jobs/docker_cpi/templates/cpi.json.erb
@@ -2,6 +2,7 @@
 
 config = {
   "start_containers_with_systemd" => p("docker_cpi.start_containers_with_systemd"),
+  "mount_cgroupfs" => p("docker_cpi.mount_cgroupfs"),
   "enable_lxcfs_support" => p("docker_cpi.enable_lxcfs_support"),
   "light_stemcell" => {
     "require_image_verification" => p("docker_cpi.light_stemcell.require_image_verification"),

--- a/src/bosh-docker-cpi/config/config.go
+++ b/src/bosh-docker-cpi/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Actions FactoryOpts
 
 	StartContainersWithSystemD bool              `json:"start_containers_with_systemd"`
+	MountCgroupfs              bool              `json:"mount_cgroupfs"`
 	EnableLXCFSSupport         bool              `json:"enable_lxcfs_support"`
 	LightStemcell              LightStemcellOpts `json:"light_stemcell"`
 }

--- a/src/bosh-docker-cpi/config/config_test.go
+++ b/src/bosh-docker-cpi/config/config_test.go
@@ -151,6 +151,7 @@ var _ = Describe("Config", func() {
 						}
 					},
 					"start_containers_with_systemd": true,
+					"mount_cgroupfs": true,
 					"enable_lxcfs_support": true,
 					"light_stemcell": {
 						"require_image_verification": true
@@ -162,11 +163,21 @@ var _ = Describe("Config", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(cfg.StartContainersWithSystemD).To(BeTrue())
+				Expect(cfg.MountCgroupfs).To(BeTrue())
 				Expect(cfg.EnableLXCFSSupport).To(BeTrue())
 				Expect(cfg.LightStemcell.RequireImageVerification).To(BeTrue())
 				Expect(cfg.Actions.Docker.Host).To(Equal("unix:///var/run/docker.sock"))
 				Expect(cfg.Actions.Docker.APIVersion).To(Equal("1.24"))
 				Expect(cfg.Actions.Agent.Mbus).To(Equal("https://user:pass@127.0.0.1:4321/agent"))
+			})
+
+			It("unmarshals mount_cgroupfs as false when set to false", func() {
+				data := `{"mount_cgroupfs": false}`
+
+				var cfg config.Config
+				err := json.Unmarshal([]byte(data), &cfg)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg.MountCgroupfs).To(BeFalse())
 			})
 
 			It("unmarshals TLS private_key json tag correctly", func() {

--- a/src/bosh-docker-cpi/vm/factory.go
+++ b/src/bosh-docker-cpi/vm/factory.go
@@ -162,10 +162,7 @@ func (f Factory) Create(agentID apiv1.AgentID, stemcell bstem.Stemcell,
 		"/lib/modules:/usr/lib/modules", // make host kernel modules accessible
 	}
 
-	if startContainersWithSystemD {
-		// systemd needs read-write access to the cgroup filesystem to manage
-		// service cgroups. Without this mount, systemd may fail to initialize
-		// on cgroups v2 hosts.
+	if cgroupBind(startContainersWithSystemD, f.Config.MountCgroupfs) {
 		binds = append(binds, "/sys/fs/cgroup:/sys/fs/cgroup:rw")
 	}
 
@@ -270,6 +267,15 @@ func populateResolveConf(networks apiv1.Networks) string {
 	}
 
 	return fmt.Sprintf(`printf '%%s\n' %s > /etc/resolv.conf`, strings.Join(nameserverEntries, " "))
+}
+
+// cgroupBind reports whether the /sys/fs/cgroup bind mount should be added to the
+// container. On cgroup-v2 hosts the bind lets systemd manage service cgroups via
+// the host hierarchy. On cgroup-v1 hosts it must be omitted because the shared
+// host mount causes runc to encounter EBUSY when it tries to rmdir an empty
+// memory cgroup whose kernel accounting charges have not yet propagated.
+func cgroupBind(startContainersWithSystemD, mountCgroupfs bool) bool {
+	return startContainersWithSystemD && mountCgroupfs
 }
 
 func (f Factory) cleanMounts(vmProps Props) Props {

--- a/src/bosh-docker-cpi/vm/factory_test.go
+++ b/src/bosh-docker-cpi/vm/factory_test.go
@@ -1,0 +1,22 @@
+package vm
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Factory", func() {
+	Describe("cgroupBind", func() {
+		It("returns true when startContainersWithSystemD and MountCgroupfs are both true", func() {
+			Expect(cgroupBind(true, true)).To(BeTrue())
+		})
+
+		It("returns false when startContainersWithSystemD is false", func() {
+			Expect(cgroupBind(false, true)).To(BeFalse())
+		})
+
+		It("returns false when MountCgroupfs is false", func() {
+			Expect(cgroupBind(true, false)).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
## Problem

On cgroup-v1 hosts the unconditional `/sys/fs/cgroup:rw` bind that systemd
containers receive via 89eb038 moves bpm/runc sub-cgroups onto the shared host hierarchy.
When `runc` attempts `rmdir` on cleanup, the kernel reports `EBUSY` because
memory accounting charges haven't been fully released yet, wedging the
container. The director deploy process hangs indefinitely waiting for the delete
to complete.

The bind swaps the mountinfo root from `/docker/<id>/` (docker's private delegated tree for this container) to `/` (the real host cgroup root). That single field change is what puts bpm's scopes in the host's shared system.slice and makes them susceptible to the `EBUSY`.  In testing, simply retrying the delete did not result in `EBUSY` going away over the course of minutes.

## Change

Add a `docker_cpi.mount_cgroupfs` job property (default `true`, preserving
existing behaviour on cgroup-v2 hosts). When set to `false` the bind is
omitted entirely; systemd manages its own cgroups within the container
namespace without touching the host hierarchy (the behavior prior to 89eb038).

## Evidence

Validated by swapping the compiled CPI binary into a live CI director deploy
on a cgroup v1 worker. Two back-to-back `bosh create-env` calls on the
same host:

| CPI | `mount_cgroupfs` | Result |
|-----|-----------------|--------|
| patched | `false` | `Waiting for bosh/0... Finished` (1m48s) ✅ |
| original | `true` (implicit) | `Waiting for bosh/0... Failed` (5m34s) ❌ |